### PR TITLE
Prevent `__len__()` and `__getitem__()` from being overridden

### DIFF
--- a/experiments/data/datasets.py
+++ b/experiments/data/datasets.py
@@ -69,12 +69,6 @@ class SequenceDataset:
         """Shape of the data in the dataset."""
         raise NotImplementedError()
 
-    def __len__(self) -> int:
-        raise NotImplementedError()
-
-    def __getitem__(self, item: int) -> tuple[torch.Tensor, int]:
-        raise NotImplementedError()
-
 
 class SMnistDataset(SequenceDataset, MNIST):
     NAME: str = "SMNIST"


### PR DESCRIPTION
Fixes #10 