### PR TITLE
Fix dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 torch>=1.10.1
-git+https://github.com/regeirk/pycwt@master#egg=pycwt
+git+https://github.com/regeirk/pycwt@main#egg=pycwt


### PR DESCRIPTION
Looks like `pycwt` renamed `master` to `main`, causing the install to fail.